### PR TITLE
Add create/deploy release Github workflow

### DIFF
--- a/.github/workflows/create-deploy-release.yml
+++ b/.github/workflows/create-deploy-release.yml
@@ -1,0 +1,26 @@
+name: Create and deploy a new release
+run-name: create and deploy ${{ github.sha }}
+on:
+  push:
+    branches:
+      - trigger-gitlab-ci
+jobs:
+  trigger-gitlab-pipeline:
+    runs-on: ubuntu-latest
+    env:
+      GITLAB_API_TOKEN: ${{ secrets.GITLAB_API_TOKEN }}
+    steps:
+      - name: configure environment
+        shell: bash
+        run: |
+          echo "REPO_PUBLIC_URL=${{ github.server_url }}/${{ github.repository }}.git" >> $GITHUB_ENV
+          echo "SCAFFOLD_DIR=scaffold" >> $GITHUB_ENV
+      - name: clone scaffold repository
+        shell: bash
+        run: git clone --depth 1 -b trigger-gitlab-ci https://oauth2:$GITLAB_API_TOKEN@${{ vars.SCAFFOLD_REPO_PUBLIC_URL }} ${{ env.SCAFFOLD_DIR }}
+      - name: trigger Gitlab CI/CD pipeline
+        shell: bash
+        run: |
+          RELEASE_VERSION="${GITHUB_SHA:0:8}"
+          ./scripts/gitlab-ci-pipeline.sh ${{ env.REPO_PUBLIC_URL }} ${{ vars.APP_NAME }} $RELEASE_VERSION
+        working-directory: ${{ env.SCAFFOLD_DIR }}

--- a/.github/workflows/create-deploy-release.yml
+++ b/.github/workflows/create-deploy-release.yml
@@ -3,7 +3,7 @@ run-name: create and deploy ${{ github.sha }}
 on:
   push:
     branches:
-      - trigger-gitlab-ci
+      - main
 jobs:
   trigger-gitlab-pipeline:
     runs-on: ubuntu-latest
@@ -17,7 +17,7 @@ jobs:
           echo "SCAFFOLD_DIR=scaffold" >> $GITHUB_ENV
       - name: clone scaffold repository
         shell: bash
-        run: git clone --depth 1 -b trigger-gitlab-ci https://oauth2:$GITLAB_API_TOKEN@${{ vars.SCAFFOLD_REPO_PUBLIC_URL }} ${{ env.SCAFFOLD_DIR }}
+        run: git clone --depth 1 https://oauth2:$GITLAB_API_TOKEN@${{ vars.SCAFFOLD_REPO_PUBLIC_URL }} ${{ env.SCAFFOLD_DIR }}
       - name: trigger Gitlab CI/CD pipeline
         shell: bash
         run: |


### PR DESCRIPTION
A simple Github workflow to trigger Gitlab CI/CD pipelines.

The workflow is triggered when a push is made to the `main` branch.