### PR TITLE
Ajout du schéma « Comptes annuels d'entreprises — format d'échange »

### DIFF
--- a/repertoires.yml
+++ b/repertoires.yml
@@ -381,7 +381,4 @@ reseaux-eaux:
 comptes-annuels-entreprises:
   url: https://github.com/TEFUDA/schema-comptes-annuels.git
   type: tableschema
-  email: contact@loicgrosflandre.com
-  external_doc: https://cnigfr.github.io/StaR-Eau/
-  labels:
-    - CNIG
+  email: loic.gros.flandre@gmail.com

--- a/repertoires.yml
+++ b/repertoires.yml
@@ -372,13 +372,16 @@ donnees-communication-publique:
   type: jsonschema
   email: sebastien.malot@pm.gouv.fr
 reseaux-eaux:
+  url: https://github.com/cnigfr/StaR-Eau.git
+  type: other
+  email: cnig@cnig.fr
+  external_doc: https://cnigfr.github.io/StaR-Eau/
+  labels:
+    - CNIG
 comptes-annuels-entreprises:
   url: https://github.com/TEFUDA/schema-comptes-annuels.git
   type: tableschema
   email: contact@loicgrosflandre.com
-  url: https://github.com/cnigfr/StaR-Eau.git
-  type: other
-  email: cnig@cnig.fr
   external_doc: https://cnigfr.github.io/StaR-Eau/
   labels:
     - CNIG

--- a/repertoires.yml
+++ b/repertoires.yml
@@ -372,6 +372,10 @@ donnees-communication-publique:
   type: jsonschema
   email: sebastien.malot@pm.gouv.fr
 reseaux-eaux:
+comptes-annuels-entreprises:
+  url: https://github.com/TEFUDA/schema-comptes-annuels.git
+  type: tableschema
+  email: contact@loicgrosflandre.com
   url: https://github.com/cnigfr/StaR-Eau.git
   type: other
   email: cnig@cnig.fr


### PR DESCRIPTION
▎ Ce schéma décrit le format d'échange des données issues des comptes annuels déposés aux greffes des tribunaux de commerce.
▎
▎ Il rend obligatoire la durée de l'exercice à côté des montants. Mesuré sur les 1 262 484 dépôts du Registre national des entreprises au 20/08/2026 : 103 184 couvrent une durée différente de douze mois — les durées observées vont de 1 à 36 mois — et 21 066 n'en déclarent aucune. Sans cette durée, deux chiffres d'affaires ne sont pas comparables, et rien dans les données ne le signale.
▎
▎ Le schéma sépare explicitement chiffre_affaires (valeur déposée, pour la durée indiquée) de chiffre_affaires_annualise (seule valeur c lisibles trois autres pièges courants : lemélange comptes consolidés / comptes sociaux, les grandeurs de stock qui ne s'annualisent pas, et le périmètre
▎ masqué par l'exclusion des comptes confide
▎
▎ Validé avec frictionless depuis les URL puhier d'exemple est constitué de dépôts réels, dont six exercices de durée différente de douze mois — par exemple CONFORAMA FRANCE sur 9 mois : 1,228 Md € bruts,
▎ 1,637 Md € annualisés.
▎
▎ Dépôt du schéma : https://github.com/TEFUD v1.0.0)